### PR TITLE
Update dxcc.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 *.iml
+__pycache__/*

--- a/dxcc.py
+++ b/dxcc.py
@@ -7,7 +7,7 @@ def getEntityCode(e):
 
 
 dxccList = []
-with open('dxcc-2020-02.csv', mode='r') as infile:
+with open('dxcc-2020-02.csv', mode='r', encoding='utf8') as infile:
     reader = csv.DictReader(infile)
     for row in reader:
         row['entityCode'] = int(row['entityCode'])


### PR DESCRIPTION
Encoding Problems from Windows 10
I get the Error: UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 2437: character maps to <undefined>
Then i insert the  ", encoding='utf8'" and the problem is fixed.